### PR TITLE
Fix FB share count error

### DIFF
--- a/angular-socialshare.js
+++ b/angular-socialshare.js
@@ -71,7 +71,7 @@ angular.module('djds4rce.angular-socialshare', [])
     link: function(scope, element, attr) {
       if(attr.shares){
         $http.get('https://api.facebook.com/method/links.getStats?urls='+attr.url+'&format=json').success(function(res){
-            var count = res[0].share_count.toString();
+            var count = res[0] ? res[0].share_count.toString() : 0;
             var decimal = '';
             if(count.length > 6){
               if(count.slice(-6,-5) != "0"){


### PR DESCRIPTION
"TypeError: Cannot read property 'share_count' of undefined" occurs in some cases, specifically if working on localhost. Fix is to add a null check and assign share count to be 0 if res[0] is undefined.
