### PR TITLE
Facebook dynamic shares counter

### DIFF
--- a/angular-socialshare.js
+++ b/angular-socialshare.js
@@ -14,23 +14,23 @@ angular.module('djds4rce.angular-socialshare', [])
       if(fbId){
         this.fbId = fbId;
         $window.fbAsyncInit = function() {
-          FB.init({ 
-            appId: fbId, 
-            channelUrl: 'app/channel.html', 
-            status: true, 
-            xfbml: true 
+          FB.init({
+            appId: fbId,
+            channelUrl: 'app/channel.html',
+            status: true,
+            xfbml: true
           });
         };
         (function(d){
-          var js,           
-          id = 'facebook-jssdk', 
+          var js,
+          id = 'facebook-jssdk',
           ref = d.getElementsByTagName('script')[0];
           if (d.getElementById(id)) {
             return;
           }
 
-          js = d.createElement('script'); 
-          js.id = id; 
+          js = d.createElement('script');
+          js.id = id;
           js.async = true;
           js.src = "//connect.facebook.net/en_US/all.js";
 
@@ -47,30 +47,31 @@ angular.module('djds4rce.angular-socialshare', [])
 }]).directive('facebook', ['$timeout','$http', function($timeout,$http) {
   return {
     scope: {
-      shares: '=' 
-    }, 
+      shares: '='
+    },
     transclude: true,
-    template: '<div class="facebookButton">' + 
-      '<div class="pluginButton">' + 
-        '<div class="pluginButtonContainer">' + 
-          '<div class="pluginButtonImage">' + 
-            '<button type="button">' + 
-              '<i class="pluginButtonIcon img sp_plugin-button-2x sx_plugin-button-2x_favblue"></i>' + 
-            '</button>' + 
-          '</div>' + 
-          '<span class="pluginButtonLabel">Share</span>' + 
-        '</div>' + 
-      '</div>' + 
-    '</div>' + 
+    template: '<div class="facebookButton">' +
+      '<div class="pluginButton">' +
+        '<div class="pluginButtonContainer">' +
+          '<div class="pluginButtonImage">' +
+            '<button type="button">' +
+              '<i class="pluginButtonIcon img sp_plugin-button-2x sx_plugin-button-2x_favblue"></i>' +
+            '</button>' +
+          '</div>' +
+          '<span class="pluginButtonLabel">Share</span>' +
+        '</div>' +
+      '</div>' +
+    '</div>' +
     '<div class="facebookCount">' +
-      '<div class="pluginCountButton pluginCountNum">' + 
+      '<div class="pluginCountButton pluginCountNum">' +
         '<span ng-transclude></span>' +
-      '</div>' + 
-      '<div class="pluginCountButtonNub"><s></s><i></i></div>' + 
+      '</div>' +
+      '<div class="pluginCountButtonNub"><s></s><i></i></div>' +
     '</div>',
     link: function(scope, element, attr) {
       if(attr.shares){
-        $http.get('https://api.facebook.com/method/links.getStats?urls='+attr.url+'&format=json').success(function(res){
+        attr.$observe('url', function(){
+          $http.get('https://api.facebook.com/method/links.getStats?urls='+attr.url+'&format=json').success(function(res){
             var count = res[0] ? res[0].share_count.toString() : 0;
             var decimal = '';
             if(count.length > 6){
@@ -87,8 +88,9 @@ angular.module('djds4rce.angular-socialshare', [])
               count = count + decimal + 'k';
             }
             scope.shares = count;
-        }).error(function(){
-          scope.shares = 0;
+          }).error(function(){
+            scope.shares = 0;
+          });
         });
       }
       $timeout(function(){
@@ -122,26 +124,26 @@ angular.module('djds4rce.angular-socialshare', [])
 }]).directive('linkedin', ['$timeout','$http', '$window',function($timeout,$http,$window) {
   return {
     scope: {
-      shares: '=' 
-    }, 
+      shares: '='
+    },
     transclude: true,
-    template: '<div class="linkedinButton">' + 
-      '<div class="pluginButton">' + 
-        '<div class="pluginButtonContainer">' + 
-          '<div class="pluginButtonImage">in' + 
-          '</div>' + 
-          '<span class="pluginButtonLabel"><span>Share</span></span>' + 
-        '</div>' + 
-      '</div>' + 
-    '</div>' + 
+    template: '<div class="linkedinButton">' +
+      '<div class="pluginButton">' +
+        '<div class="pluginButtonContainer">' +
+          '<div class="pluginButtonImage">in' +
+          '</div>' +
+          '<span class="pluginButtonLabel"><span>Share</span></span>' +
+        '</div>' +
+      '</div>' +
+    '</div>' +
     '<div class="linkedinCount">' +
-      '<div class="pluginCountButton">' + 
+      '<div class="pluginCountButton">' +
         '<div class="pluginCountButtonRight">' +
           '<div class="pluginCountButtonLeft">' +
             '<span ng-transclude></span>' +
           '</div>' +
         '</div>' +
-      '</div>' + 
+      '</div>' +
     '</div>',
     link: function(scope, element, attr) {
       if(attr.shares){
@@ -181,7 +183,7 @@ angular.module('djds4rce.angular-socialshare', [])
       element.append(tumblr_button);
     }
 
-  }  
+  }
 }]).directive('tumblrQoute',[function(){
   return {
     link: function(scope,element,attr){
@@ -191,7 +193,7 @@ angular.module('djds4rce.angular-socialshare', [])
       tumblr_button.setAttribute("style", attr.styling||"display:inline-block; text-indent:-9999px; overflow:hidden; width:81px; height:20px; background:url('http://platform.tumblr.com/v1/share_1.png') top left no-repeat transparent;");
       element.append(tumblr_button);
     }
-  }  
+  }
 }]).directive('tumblrImage',[function(){
   return {
     link: function(scope,element,attr){


### PR DESCRIPTION
Directive for counting Facebook shares seemed to be firing too early if used within an Angular template. Because of that code like this:

```
<a facebook data-url="{{ profile.url }}" data-shares="shares">{{ shares }}</a>
```

fails miserably, because the directive fires before `{{ profile.url }}` gets populated. Adding `attr.$observe` to the `url` attribute fixes the problem.
