### PR TITLE
align version numbers in package.json and bower.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-socialshare",
-  "version": "1.2",
+  "version": "1.4.1",
   "description": "Angular Social Share =========",
   "main": "angular-socialshare.js",
   "scripts": {


### PR DESCRIPTION
Trying to install this module with:

    npm install djds4rce/angular-socialshare

fails. Bumping the version number in `package.json` to be the same as in `bower.json` makes it work.

(But of course I then have to install from my fork!)