### PR TITLE
Added Hashtags attribute to the Twitter Directive

### DIFF
--- a/angular-socialshare.js
+++ b/angular-socialshare.js
@@ -180,7 +180,8 @@ angular.module('djds4rce.angular-socialshare', [])
 									count: attr.count,
 									text: attr.text,
 									via: attr.via,
-									size: attr.size
+									size: attr.size,
+									hashtags: attr.hashtags
 								}
 							);
 						});


### PR DESCRIPTION
I noticed when using your angular-socialshare that I needed use of the hashtags attribute but it wasn't available.

I have updated the main `angular-socialshare.js` file so I could use the hashtags attribute, but nothing else. If you accept the pull request a new minification will need to be ran. 

## Twitter says:
**Hashtags**
Add a comma-separated list of hashtags to a Tweet using the hashtags parameter. Omit a preceding “#” from each hashtag; the Tweet composer will automatically add the proper space-separated hashtag by language."
